### PR TITLE
Update troubleshooting instructions for XIP on macOS

### DIFF
--- a/docs/TROUBLESHOOTING_ZANT.md
+++ b/docs/TROUBLESHOOTING_ZANT.md
@@ -5,3 +5,7 @@ When using ./create remember to set  --do-user-tests --do-extract --optimize --c
 
 # -Dfuse
 When using -Dfuse ensure the -Denable_user_tests are enabled
+
+# XIP on macOS
+When using XIP on macOS you must build the static library inside the provided Docker container, 
+otherwise the build will fail due to missing toolchain support.


### PR DESCRIPTION
Added note about building static library in Docker for XIP on macOS.